### PR TITLE
Add Contributors section to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,8 +219,25 @@ Contributing
 ============
 **imagenode** is in early development and testing. I welcome open issues and
 pull requests, but because the programs are still rapidly evolving, it is best
-to open an issue with some discussion before submitting any pull requests or
-code changes.
+to open an issue for some discussion before submitting pull requests. We can
+exchange ideas about your potential pull request how to best test your code.
+
+Contributors
+============
+Thanks for all contributions big and small. Some significant ones:
+
++--------------------------+-----------------+----------------------------------------------+
+| **Contribution**         | **Name**        | **GitHub**                                   |
++--------------------------+-----------------+----------------------------------------------+
+| Initial code & docs      | Jeff Bass       | `@jeffbass <https://github.com/jeffbass>`_   |
++--------------------------+-----------------+----------------------------------------------+
+| Added code and           |                 |                                              |
+| documentation for        |                 |                                              |
+| PiCamera settings        | Stephen Kirby   | `@sbkirby <https://github.com/sbkirby>`_     |
++--------------------------+-----------------+----------------------------------------------+
+| Added DHT11 & DHT22      |                 |                                              |
+| sensor capability        | Stephen Kirby   | `@sbkirby <https://github.com/sbkirby>`_     |
++--------------------------+-----------------+----------------------------------------------+
 
 Acknowledgments
 ===============


### PR DESCRIPTION
Hi Stephen @sbkirby,
I'm adding a Contributors section to the **imagnode** `README.rst`, like the one I added to [imageZMQ](https://github.com/jeffbass/imagezmq). I really appreciate your contributions and want to recognize them. Please review this for name spelling, my description of your contributions, etc. (or, if you would prefer not to be in this section, let me know and I'll take it out.)
Thanks,
Jeff